### PR TITLE
feat:자동로그인,로그아웃 #13

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+Login.js

--- a/src/App.js
+++ b/src/App.js
@@ -67,6 +67,7 @@ function App() {
                         <Route path="/afterkakao" element={<Afterkakao />} />
                         <Route path="*" element={<NotFoundPage />} />
                         <Route path="/history" element={<PayHistory />} />
+                        <Route path="/benefitTest" element={<BenefitTest />} />
                         {/* <Route path="/memberPwd" element={<MemberPwd />} />
                         <Route path="/checkPwd" element={<CheckPwd />} /> */}
                     </Routes>

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState ,useEffect} from 'react';
 import axios from 'axios';
 import { useNavigate, Link } from 'react-router-dom';
 import Button from '../component/Button';
@@ -33,10 +33,17 @@ const Login = () => {
             const response = await axios.post(
                 'http://localhost:8091/login',
                 loginData,
+                { withCredentials: true }
             );
-
+            // console.log('Response 헤더 내용');
+            // console.log(response);
+            // console.log('액세스토큰 꺼내기');
+            // console.log(response.headers.authorization);
+            // console.log('리프레시토큰 꺼내기');
+            //console.log(response.headers.authorization-refresh);
             const accessToken = response.headers.authorization;
             const refreshToken = response.headers['authorization-refresh'];
+            //console.log(refreshToken);
 
             if (accessToken) {
                 localStorage.setItem('accessToken', accessToken);


### PR DESCRIPTION
- 한번로그인해서 쿠키에 리프레시 토큰 저장된 상태로는 브라우저 껏다켜도 로그인 프로바이더가 적용된 페이지에 직접 접근시도하면 다시 로그인 안해도 쿠키에서 리프레시토큰 가지고 다시 액세스토큰 가져온뒤에 통신
- 헤더에 달린 로그아웃 버튼 누르면 백엔드로 보내서 쿠키의 리프레시 토큰 삭제하고, DB에서도 리프레시 토큰  삭제함 -> 추후 redis에 TTL 달고 쓰면 더 좋을듯 